### PR TITLE
Add Feature: Name Java App Window

### DIFF
--- a/EZ.java
+++ b/EZ.java
@@ -942,8 +942,7 @@ public class EZ extends JPanel {
    * @param height for the content area of the window.
    */
   public static void initialize(int width, int height) {
-    initialize((int) Toolkit.getDefaultToolkit().getScreenSize().getWidth(), (int) Toolkit.getDefaultToolkit()
-        .getScreenSize().getHeight(), "ICS111");
+    initialize(width, height, "ICS111");
   }
 
   /**

--- a/EZ.java
+++ b/EZ.java
@@ -33,7 +33,6 @@ import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
-import java.awt.Image;
 import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.Shape;
@@ -915,8 +914,9 @@ public class EZ extends JPanel {
    * 
    * @param width for the content area of the window.
    * @param height for the content area of the window.
+   * @param name for the window.
    */
-  public static void initialize(int width, int height, Image icon, String name) {
+  public static void initialize(int width, int height, String name) {
     String windowName = name;
     JFrame frame = new JFrame(windowName);
     frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -925,7 +925,6 @@ public class EZ extends JPanel {
     EZ newContentPane = new EZ(width, height);
     newContentPane.setOpaque(true); // content panes must be opaque
     frame.setContentPane(newContentPane);
-    frame.setIconImage(icon);
 
     // Size the frame according to largest element, then display the window.
     frame.setResizable(false);
@@ -935,6 +934,18 @@ public class EZ extends JPanel {
     lastUpdate = System.currentTimeMillis();
   }
 
+    /**
+   * This will setup EZ for usage. Without calling this method first, none of the other EZ methods will work correctly.
+   * Window will default to use the full dimensions of the screen. Do not call this method more than once in a program
+   * run.
+   * @param width for the content area of the window.
+   * @param height for the content area of the window.
+   */
+  public static void initialize(int width, int height) {
+    initialize((int) Toolkit.getDefaultToolkit().getScreenSize().getWidth(), (int) Toolkit.getDefaultToolkit()
+        .getScreenSize().getHeight(), "ICS111");
+  }
+
   /**
    * This will setup EZ for usage. Without calling this method first, none of the other EZ methods will work correctly.
    * Window will default to use the full dimensions of the screen. Do not call this method more than once in a program
@@ -942,7 +953,7 @@ public class EZ extends JPanel {
    */
   public static void initialize() {
     initialize((int) Toolkit.getDefaultToolkit().getScreenSize().getWidth(), (int) Toolkit.getDefaultToolkit()
-        .getScreenSize().getHeight(), null, "ICS111");
+        .getScreenSize().getHeight(), "ICS111");
   }
   
   public static void trackedErrorPrint() {

--- a/EZ.java
+++ b/EZ.java
@@ -33,6 +33,7 @@ import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
+import java.awt.Image;
 import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.Shape;
@@ -915,8 +916,8 @@ public class EZ extends JPanel {
    * @param width for the content area of the window.
    * @param height for the content area of the window.
    */
-  public static void initialize(int width, int height) {
-    String windowName = "ICS111";
+  public static void initialize(int width, int height, Image icon, String name) {
+    String windowName = name;
     JFrame frame = new JFrame(windowName);
     frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
@@ -924,6 +925,7 @@ public class EZ extends JPanel {
     EZ newContentPane = new EZ(width, height);
     newContentPane.setOpaque(true); // content panes must be opaque
     frame.setContentPane(newContentPane);
+    frame.setIconImage(icon);
 
     // Size the frame according to largest element, then display the window.
     frame.setResizable(false);
@@ -940,7 +942,7 @@ public class EZ extends JPanel {
    */
   public static void initialize() {
     initialize((int) Toolkit.getDefaultToolkit().getScreenSize().getWidth(), (int) Toolkit.getDefaultToolkit()
-        .getScreenSize().getHeight());
+        .getScreenSize().getHeight(), null, "ICS111");
   }
   
   public static void trackedErrorPrint() {


### PR DESCRIPTION
Added the ability to name the window any application made with EZ is running in. This is an "optional" parameter.  

Modified the `initialize()` methods to accommodate three params: `int width, int height, String name`. Users can pass a string with a name they would like for the window and it will be assigned to `windowName` in the three parameter `initialize(int width, int height, String name)` method. 

However, should a user choose not to pass a name and use `initialize(int width, int height);` the windowName will be assigned  a default value of "ICS 111". This is done by called the three parameter `initialize(int width, int height, String name)` method and passing at the default value from with in the two parameter `initialize(int width, int height);` 

Finally, should a user choose to simply call `initialize();` the name parameter will also be passed with the default value of "ICS 111".

Adding this parameter allows users to include a unique name for their application window without modifying the EZ.java class files.

I have tested this a number of times on a Mac running OS X 10.10.5 but have not had the opportunity to run it on a windows machine.
